### PR TITLE
Add Incoming and Outgoing modifiers

### DIFF
--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -17,7 +17,7 @@ function modifyEffect(rSource, rTarget, rRoll)
     for index, effectStringComp in ipairs(effectStringComps) do
         effectComp = EffectManager.parseEffectCompSimple(effectStringComp)
         if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" and next(effectComp.remainder) then
-            combineBonusMods(bonusMods, getBonusMods(rSource, effectComp.remainder))
+            combineBonusMods(bonusMods, getBonusMods(rTarget, effectComp.remainder))
             for _, bonusType in ipairs(effectComp.remainder) do
                 if bonusMods[bonusType] then
                     effectComp.mod = effectComp.mod + bonusMods[bonusType]

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -3,7 +3,7 @@ local onEffect
 
 function onInit()
     addEffect = EffectManager.addEffect
-    EffectManager.addEffect = modifyEffectOnAdd
+    -- EffectManager.addEffect = modifyEffectOnAdd
 
     ActionsManager.registerModHandler("effect", modifyEffect);
 end
@@ -11,7 +11,26 @@ end
 function modifyEffect(rSource, rTarget, rRoll)
     -- Debug.chat(rSource, rTarget, rRoll)
     local rEffect = EffectManager.decodeEffect(rRoll);
-
+    local effectsModified = false
+    local effectStringComps = EffectManager.parseEffect(rEffect.sName)
+    local bonusMods = {}
+    for index, effectStringComp in ipairs(effectStringComps) do
+        effectComp = EffectManager.parseEffectCompSimple(effectStringComp)
+        if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" and next(effectComp.remainder) then
+            combineBonusMods(bonusMods, getBonusMods(rSource, effectComp.remainder))
+            for _, bonusType in ipairs(effectComp.remainder) do
+                if bonusMods[bonusType] then
+                    effectComp.mod = effectComp.mod + bonusMods[bonusType]
+                    effectStringComps[index] = EffectManager35E.rebuildParsedEffectComp(effectComp)
+                    effectsModified = true
+                end
+            end
+        end
+    end
+    if effectsModified then
+        rEffect.sName = EffectManager.rebuildParsedEffect(effectStringComps)
+        rRoll.sDesc = EffectManager.encodeEffect(rEffect).sDesc
+    end
 end
 
 function modifyEffectOnAdd(sUser, sIdentity, nodeCT, rNewEffect, bShowMsg, ...)

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -10,16 +10,19 @@ function modifyEffect(rSource, rTarget, rRoll)
     local bonusMods = {}
     for index, effectStringComp in ipairs(effectStringComps) do
         effectComp = EffectManager.parseEffectCompSimple(effectStringComp)
-        if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" and next(effectComp.remainder) then
-            combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", effectComp.remainder)))
-            combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("recieve", effectComp.remainder)))
-            for _, bonusType in ipairs(effectComp.remainder) do
-                if bonusMods[bonusType] then
-                    effectComp.mod = effectComp.mod + bonusMods[bonusType]
-                    effectStringComps[index] = EffectManager35E.rebuildParsedEffectComp(effectComp)
-                    effectsModified = true
-                end
-            end
+        if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" then
+			local bonusTypes = extractBonusTypes(effectComp.remainder)
+			if  #bonusTypes > 0 then
+				combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", bonusTypes)))
+				combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("recieve", bonusTypes)))
+				for _, bonusType in ipairs(bonusTypes) do
+					if bonusMods[bonusType] then
+						effectComp.mod = effectComp.mod + bonusMods[bonusType]
+						effectStringComps[index] = EffectManager35E.rebuildParsedEffectComp(effectComp)
+						effectsModified = true
+					end
+				end
+			end
         end
     end
     if effectsModified then
@@ -48,17 +51,22 @@ function combineBonusMods(existingMods, newMods)
     end
 end
 
+function extractBonusTypes(effectRemainder)
+	local bonusTypes = {}
+	for _, entry in ipairs(effectRemainder) do
+		if StringManager.contains(DataCommon.bonustypes, entry) then
+			table.insert(bonusTypes, entry)
+		end
+	end
+	return bonusTypes
+end
+
 function createEffectFilter(effectModType, effectBonusTypes)
     local filter = {effectModType}
-    if #effectBonusTypes > 0 then
-        for _, entry in ipairs(effectBonusTypes) do
-            if StringManager.contains(DataCommon.bonustypes, entry) then
-                table.insert(filter, entry)
-            end
-        end
-        return {filter}
-    end
-    return filter
+	for _, entry in ipairs(effectBonusTypes) do
+			table.insert(filter, entry)
+	end
+    return {filter}
 end
 
 -- Cloned from manger_effect_35E.lua (EffectManager35E)

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -20,8 +20,8 @@ function modifyEffect(rSource, rTarget, rRoll)
         if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" then
 			local bonusTypes = extractBonusTypes(effectComp.remainder)
 			if  #bonusTypes > 0 then
-				combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", bonusTypes)))
-				combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("recieve", bonusTypes)))
+				combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", bonusTypes), rTarget))
+				combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("recieve", bonusTypes), rSource))
 				for _, bonusType in ipairs(bonusTypes) do
 					if bonusMods[bonusType] then
 						effectComp.mod = effectComp.mod + bonusMods[bonusType]
@@ -39,8 +39,8 @@ function modifyEffect(rSource, rTarget, rRoll)
 	return true
 end
 
-function getBonusMods(rActor, bonusTypeFilter)
-    local bonusModsEffects = getEffectsByType(rActor, "BONUSMOD", bonusTypeFilter)
+function getBonusMods(rActor, bonusTypeFilter, rFilterActor)
+    local bonusModsEffects = getEffectsByType(rActor, "BONUSMOD", bonusTypeFilter, rFilterActor)
     local bonusSum = {}
     for _, bonusMod in ipairs(bonusModsEffects) do
 		local bonus = getBonusModKeys(bonusMod.remainder)

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -1,8 +1,17 @@
 local addEffect
+local onEffect
 
 function onInit()
     addEffect = EffectManager.addEffect
     EffectManager.addEffect = modifyEffectOnAdd
+
+    ActionsManager.registerModHandler("effect", modifyEffect);
+end
+
+function modifyEffect(rSource, rTarget, rRoll)
+    -- Debug.chat(rSource, rTarget, rRoll)
+    local rEffect = EffectManager.decodeEffect(rRoll);
+
 end
 
 function modifyEffectOnAdd(sUser, sIdentity, nodeCT, rNewEffect, bShowMsg, ...)

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -20,7 +20,7 @@ function modifyEffect(rSource, rTarget, rRoll)
         if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" then
 			local bonusTypes = extractBonusTypes(effectComp.remainder)
 			if  #bonusTypes > 0 then
-				combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", bonusTypes), rTarget))
+				combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("create", bonusTypes), rTarget))
 				combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("receive", bonusTypes), rSource))
 				for _, bonusType in ipairs(bonusTypes) do
 					if bonusMods[bonusType] then

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -11,8 +11,8 @@ function modifyEffect(rSource, rTarget, rRoll)
     for index, effectStringComp in ipairs(effectStringComps) do
         effectComp = EffectManager.parseEffectCompSimple(effectStringComp)
         if effectComp.type ~= '' and effectComp.type ~= "BONUSMOD" and next(effectComp.remainder) then
-            combineBonusMods(bonusMods, getBonusMods(rSource, addAllBonusTypes({"apply"}, effectComp.remainder)))
-            combineBonusMods(bonusMods, getBonusMods(rTarget, addAllBonusTypes({"recieve"}, effectComp.remainder)))
+            combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", effectComp.remainder)))
+            combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("recieve", effectComp.remainder)))
             for _, bonusType in ipairs(effectComp.remainder) do
                 if bonusMods[bonusType] then
                     effectComp.mod = effectComp.mod + bonusMods[bonusType]
@@ -48,13 +48,17 @@ function combineBonusMods(existingMods, newMods)
     end
 end
 
-function addAllBonusTypes(list1, list2)
-    for _, entry in ipairs(list2) do
-        if StringManager.contains(DataCommon.bonustypes, entry) then
-            table.insert(list1, entry)
+function createEffectFilter(effectModType, effectBonusTypes)
+    local filter = {effectModType}
+    if #effectBonusTypes > 0 then
+        for _, entry in ipairs(effectBonusTypes) do
+            if StringManager.contains(DataCommon.bonustypes, entry) then
+                table.insert(filter, entry)
+            end
         end
+        return {filter}
     end
-    return list1
+    return filter
 end
 
 -- Cloned from manger_effect_35E.lua (EffectManager35E)

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -32,9 +32,7 @@ function modifyEffect(rSource, rTarget, rRoll)
 end
 
 function getBonusMods(rActor, bonusTypeFilter)
-    Debug.chat(bonusTypeFilter)
     local bonusModsEffects = getEffectsByType(rActor, "BONUSMOD", bonusTypeFilter)
-    Debug.chat(bonusModsEffects)
     local bonusSum = {}
     for _, bonusMod in ipairs(bonusModsEffects) do
         local bonus = (bonusMod.remainder[1] or "any")

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -2,7 +2,6 @@ function onInit()
     ActionsManager.registerModHandler("effect", modifyEffect);
 end
 
--- applied & recieved
 function modifyEffect(rSource, rTarget, rRoll)
     local rEffect = EffectManager.decodeEffect(rRoll);
     local effectsModified = false

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -46,7 +46,7 @@ function getBonusMods(rActor, bonusTypeFilter)
 	Debug.chat(bonusModsEffects)
     local bonusSum = {}
     for _, bonusMod in ipairs(bonusModsEffects) do
-		local bonus = getBonusModTypes(bonusMod.remainder[1])
+		local bonus = getBonusModTypes(bonusMod.remainder)
         bonusSum[bonus] = (bonusSum[bonus] or 0) + bonusMod.mod
     end
     return bonusSum
@@ -65,9 +65,7 @@ end
 
 function combineBonusMods(existingMods, newMods)
     for bonusType, bonus in pairs(newMods) do
-        if not existingMods[bonusType] then
-            existingMods[bonusType] = existingMods[bonusType] + bonus
-        end
+		existingMods[bonusType] = (existingMods[bonusType] or 0) + bonus
     end
 end
 

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -21,7 +21,7 @@ function modifyEffect(rSource, rTarget, rRoll)
 			local bonusTypes = extractBonusTypes(effectComp.remainder)
 			if  #bonusTypes > 0 then
 				combineBonusMods(bonusMods, getBonusMods(rSource, createEffectFilter("apply", bonusTypes), rTarget))
-				combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("recieve", bonusTypes), rSource))
+				combineBonusMods(bonusMods, getBonusMods(rTarget, createEffectFilter("receive", bonusTypes), rSource))
 				for _, bonusType in ipairs(bonusTypes) do
 					if bonusMods[bonusType] then
 						effectComp.mod = effectComp.mod + bonusMods[bonusType]

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -1,8 +1,6 @@
 local onEffect
 
 function onInit()
-    -- ActionsManager.registerModHandler("effect", modifyEffect);
-
 	onEffect = ActionEffect.onEffect
 	ActionEffect.onEffect = onEffectModify
 end
@@ -13,7 +11,7 @@ function onEffectModify(rSource, rTarget, rRoll, ...)
 end
 
 function modifyEffect(rSource, rTarget, rRoll)
-    local rEffect = EffectManager.decodeEffect(rRoll);
+    local rEffect = EffectManager.decodeEffect(rRoll)
     local effectsModified = false
     local effectStringComps = EffectManager.parseEffect(rEffect.sName)
     local bonusMods = {}

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -45,14 +45,14 @@ function getBonusMods(rActor, bonusTypeFilter)
     local bonusModsEffects = getEffectsByType(rActor, "BONUSMOD", bonusTypeFilter)
     local bonusSum = {}
     for _, bonusMod in ipairs(bonusModsEffects) do
-		local bonus = getBonusModTypes(bonusMod.remainder)
+		local bonus = getBonusModKeys(bonusMod.remainder)
         bonusSum[bonus] = (bonusSum[bonus] or 0) + bonusMod.mod
     end
     return bonusSum
 end
 
-function getBonusModTypes(bonusModRemainers)
-	local bonusTypes = extractBonusTypes(bonusModRemainers)
+function getBonusModKeys(effectRemainder)
+	local bonusTypes = extractBonusTypes(effectRemainder)
 	if #bonusTypes == 0 then
 		return "any"
 	elseif #bonusTypes == 1 then
@@ -60,12 +60,6 @@ function getBonusModTypes(bonusModRemainers)
 	else
 		return table.sort(bonusTypes)
 	end
-end
-
-function combineBonusMods(existingMods, newMods)
-    for bonusType, bonus in pairs(newMods) do
-		existingMods[bonusType] = (existingMods[bonusType] or 0) + bonus
-    end
 end
 
 function extractBonusTypes(effectRemainder)
@@ -76,6 +70,12 @@ function extractBonusTypes(effectRemainder)
 		end
 	end
 	return bonusTypes
+end
+
+function combineBonusMods(existingMods, newMods)
+    for bonusType, bonus in pairs(newMods) do
+		existingMods[bonusType] = (existingMods[bonusType] or 0) + bonus
+    end
 end
 
 function createEffectFilter(effectModType, effectBonusTypes)

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -81,7 +81,7 @@ function createEffectFilter(effectModType, effectBonusTypes)
 	for _, entry in ipairs(effectBonusTypes) do
 			table.insert(filter, entry)
 	end
-    return {filter}
+    return filter
 end
 
 -- Cloned from manger_effect_35E.lua (EffectManager35E)
@@ -93,6 +93,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 	
 	-- Set up filters
 	local aRangeFilter = {};
+	local aBonusFilter = {};
 	local aOtherFilter = {};
 	if aFilter then
 		for _,v in pairs(aFilter) do
@@ -100,6 +101,8 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 				table.insert(aOtherFilter, v);
 			elseif StringManager.contains(DataCommon.rangetypes, v) then
 				table.insert(aRangeFilter, v);
+			elseif StringManager.contains(DataCommon.bonustypes, v) then
+				table.insert(aBonusFilter, v);
 			else
 				table.insert(aOtherFilter, v);
 			end
@@ -142,6 +145,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 					else
 						-- Strip energy/bonus types for subtype comparison
 						local aEffectRangeFilter = {};
+						local aEffectBonusFilter = {};
 						local aEffectOtherFilter = {};
 						
 						local aComponents = {};
@@ -181,6 +185,8 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 								-- Skip
 							elseif StringManager.contains(DataCommon.rangetypes, aComponents[j]) then
 								table.insert(aEffectRangeFilter, aComponents[j]);
+							elseif StringManager.contains(DataCommon.bonustypes, aComponents[j]) then
+								table.insert(aEffectBonusFilter, aComponents[j]);
 							else
 								table.insert(aEffectOtherFilter, aComponents[j]);
 							end
@@ -209,6 +215,18 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 									end
 								end
 								if not bRangeMatch then
+									comp_match = false;
+								end
+							end
+							if #aEffectBonusFilter > 0 then
+								local bBonusMatch = false;
+								for _,v2 in pairs(aBonusFilter) do
+									if StringManager.contains(aEffectBonusFilter, v2) then
+										bBonusMatch = true;
+										break;
+									end
+								end
+								if not bBonusMatch then
 									comp_match = false;
 								end
 							end

--- a/scripts/manager_effect_effect.lua
+++ b/scripts/manager_effect_effect.lua
@@ -43,7 +43,6 @@ end
 
 function getBonusMods(rActor, bonusTypeFilter)
     local bonusModsEffects = getEffectsByType(rActor, "BONUSMOD", bonusTypeFilter)
-	Debug.chat(bonusModsEffects)
     local bonusSum = {}
     for _, bonusMod in ipairs(bonusModsEffects) do
 		local bonus = getBonusModTypes(bonusMod.remainder)


### PR DESCRIPTION
Adds the `create` and `receive` as descriptors to indicating that Effects are modified when they're created by a character (like casting Bless), or received from others respectively (being a target of Bless).